### PR TITLE
A few README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Azure Digital Twins Postman Collection
 
-The repo contains a single postman_collection.json file that contains a postman collection of requests to the Azure Digital Twins APIs. Currently the focus of the collection is on on the data plan and includes Models, Query, and Twins.
+The repo contains a single postman_collection.json file that contains a postman collection of requests to the Azure Digital Twins APIs. Currently the focus of the collection is on on the data plane and includes Models, Query, and Twins.
 
-We will continue to add updates to the collection on a regular basis untill all Data plane and control plane API requests are created. If you have any suggestions or problems please create an Issue. If you have any question or want to discuss something, please post in the discussion tab.
+We will continue to add updates to the collection on a regular basis until all data plane and control plane API requests are created. If you have any suggestions or problems please create an issue. If you have any question or want to discuss something, please post in the discussion tab.
 
-[Full REST API documentation](https://docs.microsoft.com/en-us/rest/api/azure-digitaltwins/)
+[Full REST API documentation](https://docs.microsoft.com/rest/api/azure-digitaltwins/)
 
-[How to use Postman with Azure Digital Twins](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-postman)
+[How to use Postman with Azure Digital Twins](https://docs.microsoft.com/azure/digital-twins/how-to-use-postman)
 
 ## Contributing
 
@@ -24,8 +24,6 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ The repo contains a single postman_collection.json file that contains a postman 
 
 We will continue to add updates to the collection on a regular basis until all data plane and control plane API requests are created. If you have any suggestions or problems please create an issue. If you have any question or want to discuss something, please post in the discussion tab.
 
-[Full REST API documentation](https://docs.microsoft.com/rest/api/azure-digitaltwins/)
+For more information on the APIs used in this collection and instructions for using Postman with Azure Digital Twins, please see the following resources:
 
-[How to use Postman with Azure Digital Twins](https://docs.microsoft.com/azure/digital-twins/how-to-use-postman)
+* [Azure Digital Twins REST API reference](https://docs.microsoft.com/rest/api/azure-digitaltwins/) *(full REST API documentation)*
+* [How to use Postman to send requests to the Azure Digital Twins APIs](https://docs.microsoft.com/azure/digital-twins/how-to-use-postman) *(step-by-step instructions to set up bearer token, import collections, and run individual requests)*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ We will continue to add updates to the collection on a regular basis until all d
 
 For more information on the APIs used in this collection and instructions for using Postman with Azure Digital Twins, please see the following resources:
 
-* [Azure Digital Twins REST API reference](https://docs.microsoft.com/rest/api/azure-digitaltwins/) *(full REST API documentation)*
-* [How to use Postman to send requests to the Azure Digital Twins APIs](https://docs.microsoft.com/azure/digital-twins/how-to-use-postman) *(step-by-step instructions to set up bearer token, import collections, and run individual requests)*
+* [Azure Digital Twins REST API reference](https://docs.microsoft.com/rest/api/azure-digitaltwins/)
+* [How to use Postman to send requests to the Azure Digital Twins APIs](https://docs.microsoft.com/azure/digital-twins/how-to-use-postman)
 
 ## Contributing
 


### PR DESCRIPTION
Saw that referrals to the [doc article](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-postman?tabs=data-plane) from this repo bounce like 50% of the time, so adding a little extra description to introduce the resource links in hopes that it will help readers decide ahead of time whether the doc will be useful to them instead of just clicking it and bouncing.

Also fixed a few typos while editing